### PR TITLE
docs: repoint mirror at normalized Gitea repo checkout paths

### DIFF
--- a/docker/hister/docker-compose.yml
+++ b/docker/hister/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - HISTER__APP__REDIRECT_ON_NO_RESULTS=true
     volumes:
       - /opt/appdata/hister:/hister/data
-      - /home/ted/repos/gitea/agent-platform:/mnt/agent-platform-kb:ro
-      - /home/ted/repos/gitea/host-forge:/mnt/host-forge-kb:ro
+      - /home/ted/repos/gitea/agent-platform-knowledge-base:/mnt/agent-platform-kb:ro
+      - /home/ted/repos/gitea/host-forge-knowledge-base:/mnt/host-forge-kb:ro
       - /home/ted/.claude/memory/shared:/mnt/memory-shared:ro
     networks:
       - forge-net

--- a/docs/components/ai-search/hister.md
+++ b/docs/components/ai-search/hister.md
@@ -14,8 +14,8 @@ SearXNG for a web search fallback.
 
 | Mount | Content |
 |-------|---------|
-| `/mnt/agent-platform-kb` | `~/repos/gitea/agent-platform` (read-only) |
-| `/mnt/host-forge-kb` | `~/repos/gitea/host-forge` (read-only) |
+| `/mnt/agent-platform-kb` | `~/repos/gitea/agent-platform-knowledge-base` (read-only) |
+| `/mnt/host-forge-kb` | `~/repos/gitea/host-forge-knowledge-base` (read-only) |
 | `/mnt/memory-shared` | `~/.claude/memory/shared/` (read-only) |
 
 The agent-platform and host-forge KB repos are the primary reference material for forge

--- a/docs/components/foundation/forge-configs.md
+++ b/docs/components/foundation/forge-configs.md
@@ -6,7 +6,7 @@ Version-controlled non-secret config files for forge Docker services, with Vault
 
 ## What it is
 
-`forge-configs` is a Gitea repo (`host-forge/forge-configs`) that tracks SWAG nginx configuration and Grafana provisioning files from `/opt/appdata`. It separates non-secret configs (version-controlled in git) from secrets (stored in Vault KV at `secret/data/forge/docker/<service>`). The deploy script merges both — pulling configs from the repo and secrets from Vault — to produce the live service configuration.
+`forge-configs` is a Gitea repo (`host-forge/configs`) that tracks SWAG nginx configuration and Grafana provisioning files from `/opt/appdata`. It separates non-secret configs (version-controlled in git) from secrets (stored in Vault KV at `secret/data/forge/docker/<service>`). The deploy script merges both — pulling configs from the repo and secrets from Vault — to produce the live service configuration.
 
 The repo also serves as the source of truth for Phase 2f of `agent-workspace-scan`: the scanner checksums all tracked files hourly against the repo copies and alerts on divergence, catching out-of-band edits to `/opt/appdata` that bypass the git workflow.
 
@@ -16,8 +16,8 @@ The repo also serves as the source of truth for Phase 2f of `agent-workspace-sca
 
 | Item | Value |
 |------|-------|
-| Repo path | `~/repos/gitea/forge-configs/` |
-| Gitea remote | `gitea.tadmstr.me/host-forge/forge-configs` |
+| Repo path | `~/repos/gitea/host-forge-configs/` |
+| Gitea remote | `gitea.tadmstr.me/host-forge/configs` |
 | Deploy script | `~/scripts/forge-configs-deploy.sh` |
 | Log | `~/.claude/logs/forge-configs-deploy.log` |
 | Vault KV mount | `secret/data/forge/docker/<service>` (KV v2) |
@@ -63,7 +63,7 @@ Vault AppRole policy scope: `secret/data/forge/docker/*` (read only).
 
 - **Vault** at `http://127.0.0.1:8200` — must be unsealed for `.env` deployment; use `--skip-env` flag to deploy config files only when Vault is unavailable
 - **git** — deploy script requires clean `main` branch before deploying
-- **agent-workspace-scan** — Phase 2f reads this repo; scanner must have `~/repos/gitea/forge-configs/` accessible
+- **agent-workspace-scan** — Phase 2f reads this repo; scanner must have `~/repos/gitea/host-forge-configs/` accessible
 
 ---
 

--- a/docs/components/platform/git-drift-alert.md
+++ b/docs/components/platform/git-drift-alert.md
@@ -21,8 +21,8 @@ alerts. Re-alerts only when drift state changes — not on every scan.
 | `~/.claude/skills` | agent-platform/skills |
 | `~/repos/gitea/host-forge-scripts` | host-forge/scripts |
 | `~/repos/gitea/host-forge-build-reports` | host-forge/build-reports |
-| `~/repos/gitea/agent-platform` | agent-platform/kb |
-| `~/repos/gitea/host-forge` | host-forge/docs |
+| `~/repos/gitea/agent-platform-knowledge-base` | agent-platform/kb |
+| `~/repos/gitea/host-forge-knowledge-base` | host-forge/docs |
 
 ## How It Works
 

--- a/docs/operations/runbooks.md
+++ b/docs/operations/runbooks.md
@@ -11,8 +11,8 @@ Two types of runbooks exist on forge:
 
 ### Repository
 
-Gitea: `host-forge/forge-runbooks`  
-Local: `/home/ted/repos/gitea/forge-runbooks/`  
+Gitea: `host-forge/runbooks`  
+Local: `/home/ted/repos/gitea/host-forge-runbooks/`  
 QMD collection: `forge-runbooks` (refreshed hourly by `qmd-refresh` PM2 cron)
 
 ### Invoking a runbook
@@ -48,7 +48,7 @@ Each runbook file has YAML frontmatter (`name`, `description`, `scope`, `severit
 
 ### Adding a runbook
 
-1. Create `/home/ted/repos/gitea/forge-runbooks/<name>.md` following the format above
+1. Create `/home/ted/repos/gitea/host-forge-runbooks/<name>.md` following the format above
 2. Add a row to `forge-runbooks/index.md`
 3. Add a row to the skill's available runbooks table: `agent-platform-skills/runbook/SKILL.md`
 4. Commit both repos to main; QMD will index on the next hourly refresh
@@ -230,6 +230,6 @@ See [appdata-layout.md](appdata-layout.md) for the full `/opt/appdata/` director
 2. Add secrets to `~/.secrets/forge.env` if needed
 3. Add to NFS backup scope in Atlas config
 4. Add to `~/docs/doc-sync.yml` if official docs exist
-5. Update `~/repos/gitea/host-forge/stacks/stack-inventory.md`
-6. Update `~/repos/gitea/host-forge/services.md` port registry
+5. Update `~/repos/gitea/host-forge-knowledge-base/stacks/stack-inventory.md`
+6. Update `~/repos/gitea/host-forge-knowledge-base/services.md` port registry
 7. Deploy: `cd ~/docker/<stack-name> && docker compose up -d`

--- a/scripts/git-drift-alert.sh
+++ b/scripts/git-drift-alert.sh
@@ -18,8 +18,8 @@ declare -A REPOS=(
   ["$HOME/.claude/skills"]="agent-platform/skills"
   ["$HOME/repos/gitea/host-forge-scripts"]="host-forge/scripts"
   ["$HOME/repos/gitea/host-forge-build-reports"]="host-forge/build-reports"
-  ["$HOME/repos/gitea/agent-platform"]="agent-platform/kb"
-  ["$HOME/repos/gitea/host-forge"]="host-forge/docs"
+  ["$HOME/repos/gitea/agent-platform-knowledge-base"]="agent-platform/kb"
+  ["$HOME/repos/gitea/host-forge-knowledge-base"]="host-forge/docs"
 )
 
 DIRTY_REPOS=()


### PR DESCRIPTION
Part of build `repo-path-normalization-2026-07` (vikunja#271), run 2 of 3.

Every local Gitea checkout on forge is now named `<gitea-org>-<repo_name>`, and three Gitea repos were renamed server-side to remove stutters:

| Before | After |
|---|---|
| `host-forge/forge-configs` | `host-forge/configs` |
| `host-forge/forge-runbooks` | `host-forge/runbooks` |
| `ted/agent-templates` | `agent-platform/templates` (org transfer + rename) |

## Changed

- `docker/hister/docker-compose.yml` — KB bind mounts. Verified byte-identical to the live `~/docker` copy.
- `scripts/git-drift-alert.sh` — the two renamed paths in the `REPOS` map.
- `docs/components/foundation/forge-configs.md`, `docs/components/ai-search/hister.md`, `docs/components/platform/git-drift-alert.md`, `docs/operations/runbooks.md`

## Known gap, deliberately not fixed here

`scripts/git-drift-alert.sh` in this mirror is **one build behind** the real `host-forge/scripts` copy. The hardcoded `REPOS` map edited in this PR was replaced upstream by container-root enumeration in `agent-workspace-scan-enumeration-2026-07`, and that rewrite was never mirrored. `docs/components/platform/git-drift-alert.md` likewise still documents the removed map.

Syncing the enumeration rewrite and rewriting its doc is a different change from a path rename, so it is not folded in here. Tracked separately. This PR keeps the mirror path-correct in the meantime — nothing in it points at a directory that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)