### PR TITLE
Add AGENT_WORKSPACE.md markers — doc workflow and writer ownership

### DIFF
--- a/AGENT_WORKSPACE.md
+++ b/AGENT_WORKSPACE.md
@@ -1,0 +1,53 @@
+---
+git_backed: true
+remote: github
+branch_required: false
+access: readwrite
+inherit: true
+owning_agent: shared
+pre_edit_skill: git-config-tracking
+notes: "TadMSTR/homelab-agent on GitHub — remote inherited from the ~/repos/personal/ root marker is correct. branch_required is overridden to false: 346 of 350 commits are direct-to-main, across every subdirectory, not just docs/. Ownership is shared rather than developer — writer owns docs/ per ADR-0003 (see docs/AGENT_WORKSPACE.md), while scripts/, docker/, pm2/ and manifests/ hold developer- and sysadmin-maintained mirror copies. inherit: true so subdirectories without their own marker fall through to this one."
+---
+
+# homelab-agent — forge
+
+Public GitHub repo (`TadMSTR/homelab-agent`) serving as a generic reference for the forge
+agent platform. This marker overrides the `~/repos/personal/` root marker, which declares
+`branch_required: true, owning_agent: developer` for every child via `inherit: true`.
+
+## Why `branch_required: false`
+
+The repo's actual practice is direct-to-main by a wide margin — **346 of 350 commits**, with
+only 4 merge commits in its entire history. That holds across every subdirectory, not just
+`docs/`:
+
+| Subdirectory | Commits | Practice |
+|---|---|---|
+| `docs/` | 212 | Direct-to-main doc commits, writer- and agent-authored |
+| `pm2/` | 23 | Direct-to-main |
+| `docker/` | 22 | Direct-to-main (1 recent PR) |
+| `scripts/` | 20 | Direct-to-main (1 recent PR) |
+| `mcp-servers/` | 16 | Direct-to-main |
+| `claude-code/` | 13 | Direct-to-main |
+| `manifests/` | 7 | Direct-to-main |
+
+The inherited `branch_required: true` was surfaced during the writer's PR #291 merge: the
+writer correctly followed it, then flagged that it doesn't fit the repo's doc-only workflow.
+Setting it to `false` permits direct commits; it does not require them. Use a branch for
+anything substantive — the four merges in history were all substantive changes.
+
+## Why `owning_agent: shared`
+
+The repo mixes two ownerships, so no single agent is accurate at the root:
+
+- `docs/` — writer, per **ADR-0003** (component docs → `docs/components/`, runbooks →
+  `docs/operations/`). Declared explicitly in `docs/AGENT_WORKSPACE.md`.
+- `scripts/`, `docker/`, `pm2/`, `manifests/` — developer- and sysadmin-maintained mirror
+  copies kept in sync with `host-forge-scripts` and `host-forge/stacks`. These fall through
+  to this marker via `inherit: true`.
+
+## Public-repo constraint
+
+Per ADR-0003, content here must be **PII-free**: no forge-specific hostnames, IPs, or
+internal paths. Use generic examples (`example.com`, `192.168.x.x`, `~/repos/personal/<repo>/`).
+Phase-docs (forge-specific build records) belong in Gitea `host-forge/phases/`, not here.

--- a/docs/AGENT_WORKSPACE.md
+++ b/docs/AGENT_WORKSPACE.md
@@ -1,0 +1,36 @@
+---
+git_backed: true
+remote: github
+branch_required: false
+access: readwrite
+inherit: false
+owning_agent: writer
+pre_edit_skill: git-config-tracking
+notes: "Writer-owned per ADR-0003 (agent-platform-agents/decisions/0003-writer-doc-queue-routes-to-homelab-agent.md), which routes component docs to docs/components/ and runbooks to docs/operations/. Overrides owning_agent: shared from the repo-root marker; branch_required: false matches it and the repo's actual direct-to-main doc workflow (212 doc commits, effectively all direct). Content must be PII-free — this is a public repo."
+---
+
+# homelab-agent/docs — writer-owned
+
+## Why this marker exists
+
+**ADR-0003** (accepted 2026-06-21) routes the writer agent's doc-queue output here:
+
+- `component` → `docs/components/`
+- `runbook` → `docs/operations/`
+- `phase-doc` → **not here** — Gitea `host-forge/phases/`, because build records contain
+  forge-specific detail unsuitable for a public repo
+
+The repo-root marker declares `owning_agent: shared`, which is accurate for the repo as a
+whole but not for this subtree. This override records the writer's ownership where it
+actually applies, without claiming it over the developer/sysadmin mirror directories.
+
+`branch_required: false` matches the repo root and the real workflow — 212 commits touch
+`docs/`, effectively all direct to `main`. This was the specific mismatch surfaced during
+the writer's PR #291 merge, where the writer followed the inherited `branch_required: true`
+and then flagged that it doesn't fit a doc-only workflow.
+
+## Public-repo constraint
+
+Per ADR-0003, content here must be **PII-free**: no forge-specific hostnames, IPs, or
+internal paths. Use generic examples (`example.com`, `192.168.x.x`, `~/repos/personal/<repo>/`)
+when concrete values are needed.


### PR DESCRIPTION
## What

Adds two `AGENT_WORKSPACE.md` markers: one at the repo root, one at `docs/`.

## Why

The `~/repos/personal/` root marker declares `remote: github, branch_required: true, owning_agent: developer` for all 53 children via `inherit: true`, with zero per-repo overrides. `remote` is correct here; the other two are not.

This surfaced during the writer's PR #291 merge — the writer correctly followed the inherited `branch_required: true`, then flagged that it doesn't fit the repo's doc-only workflow.

### Root marker — `branch_required: false`, `owning_agent: shared`

**346 of 350 commits are direct-to-main** (4 merges in the entire history), and that holds across every subdirectory, not just `docs/`:

| Subdirectory | Commits |
|---|---|
| `docs/` | 212 |
| `pm2/` | 23 |
| `docker/` | 22 |
| `scripts/` | 20 |
| `mcp-servers/` | 16 |
| `claude-code/` | 13 |
| `manifests/` | 7 |

Notably `scripts/` and `docker/` — the developer/sysadmin mirror directories — are also direct-to-main (1 of the last 12 came via PR). So a subdirectory split declaring `branch_required: true` on the mirror paths would have recreated the same declared-vs-actual gap this change exists to close.

`owning_agent: shared` because the repo genuinely mixes ownerships; no single agent is accurate at the root. `inherit: true` so unmarked subdirectories fall through.

### `docs/` marker — `owning_agent: writer`

Records **ADR-0003**, which routes `component` docs to `docs/components/` and `runbook` docs to `docs/operations/`, with phase-docs excluded from this public repo. Declares writer ownership where it actually applies rather than claiming it over the mirror directories. `branch_required: false` matches the root.

## Mechanism note

`agent-workspace-check` resolves by walking up from the target path and taking the **first** marker found — closest wins. The root marker's `notes:` field is prose, parsed by nothing. Per-repo files are the only change that affects real enforcement.

## Risk

Declarative metadata only, no code or doc content touched. `branch_required: false` permits direct commits, it does not require them. `agent-workspace-scan.py` picks both markers up automatically and they satisfy `REQUIRED_FIELDS` + `GIT_ONLY_FIELDS`. No CI in this repo.

Vikunja id 292 (identifier #281) · Build plan `personal-repos-workspace-marker-fix-2026-07` Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)