### PR TITLE
pm2: mark the example as an inventory, not a runnable config

### DIFF
--- a/pm2/README.md
+++ b/pm2/README.md
@@ -1,16 +1,29 @@
 # PM2 Services
 
-PM2 manages the forge platform's always-on MCP servers and scheduled background jobs. All processes are defined in `ecosystem.config.js.example`.
+PM2 manages the forge platform's always-on MCP servers and scheduled background jobs.
+
+`ecosystem.config.js.example` in this directory lists **which** processes exist. It is an
+inventory, not a working configuration — each entry carries only `name`, `script` and
+`autorestart`, and none carries the `interpreter`, `args`, `cwd` or `env` the process needs
+to actually run.
 
 ## Usage
 
+**Do not `cp` the example and start it.** Doing so launches misconfigured processes under
+the correct names, and the next `pm2 save` then overwrites the real definitions with the
+broken ones.
+
+Each service's start definition lives in an `ecosystem.config.js` in that service's own
+repository, next to the code it starts. To bring up a service, start it from there:
+
 ```bash
-cp ecosystem.config.js.example ecosystem.config.js
-# Edit paths if they differ from $HOME/repos/personal/ layout
-pm2 start ecosystem.config.js
+pm2 start /path/to/<service-repo>/ecosystem.config.js
 pm2 save
 pm2 startup   # follow the printed command to enable boot start
 ```
+
+Keeping each definition beside its own code is deliberate: a single central file drifts from
+what is deployed, and the drift is invisible until something needs restarting.
 
 ## Process Categories
 

--- a/pm2/ecosystem.config.js.example
+++ b/pm2/ecosystem.config.js.example
@@ -1,5 +1,28 @@
 // PM2 Ecosystem Configuration — Forge Platform
 //
+// ============================================================================
+// THIS IS AN ILLUSTRATIVE INVENTORY, NOT A WORKING CONFIG. DO NOT START IT.
+// ============================================================================
+//
+// Every entry below carries only `name`, `script` and `autorestart`. None
+// carries the `interpreter`, `args`, `cwd` or `env` the process actually needs.
+// Copying this file and running `pm2 start` on it does not reproduce the
+// platform — it starts 44 misconfigured processes under the right names, which
+// is worse than starting nothing, because `pm2 save` will then overwrite good
+// definitions with these.
+//
+// It is also not a template in the usual sense: the paths are interpolated from
+// $HOME rather than left as placeholders, so it resolves to real, plausible
+// locations on any machine and fails at runtime rather than at copy time.
+//
+// Read it as documentation of WHICH processes exist. For definitions that can
+// actually start something, see the ecosystem.config.js in each service's own
+// repository, which is where they live.
+//
+// Anything that audits PM2 coverage by globbing for ecosystem files must
+// exclude *example* — otherwise this file answers "is every process declared?"
+// with a confident yes on behalf of 44 processes it cannot start.
+//
 // PM2 manages long-running MCP services and scheduled background jobs.
 // Services fall into two categories:
 //   - Always-on: daemons that run continuously (MCP servers, watchers)


### PR DESCRIPTION
## What

Adds a prominent header to `pm2/ecosystem.config.js.example` stating it is an inventory rather than a working config, and rewrites `pm2/README.md` to stop instructing readers to copy and start it.

## Why

The file names 44 apps carrying only `name`, `script` and `autorestart` — no `env`, `interpreter`, `args` or `cwd`. It cannot start any of them correctly.

The README told you to `cp ecosystem.config.js.example ecosystem.config.js && pm2 start`. Following that launches 44 misconfigured processes under the *correct names*, and the next `pm2 save` then overwrites the real definitions with the broken ones. That is worse than starting nothing.

It is also not a template in the usual sense: paths interpolate from `$HOME` rather than being placeholders, so it resolves to plausible real locations on any machine and fails at runtime instead of at copy time. (A 2026-03 audit recorded it as using `YOUR_USER` placeholders — it has none.)

## Why keep it rather than delete it

It is this repo's documentation of which processes exist, and the coverage check that could be fooled by it already excludes `*example*` and requires tracked files. Deleting a documented public template to satisfy a checker that already ignores it would be fixing the wrong layer.

The README now points at each service's own `ecosystem.config.js`, which is where the real definitions live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)